### PR TITLE
Update src/mod_restful.erl

### DIFF
--- a/src/mod_restful.erl
+++ b/src/mod_restful.erl
@@ -120,7 +120,7 @@ handle_call({get_spec, Path}, _From, #state{api = API,
             {reply, {error, not_found}, State}
     end;
 handle_call(stop, _From, State) ->
-    {stop, normal, State};
+    {stop, normal, ok, State};
 handle_call(_Req, _From, State) ->
     {reply, {error, badarg}, State}.
 


### PR DESCRIPTION
a stop reply from within handle_call needs to include use the {stop, Reason, Reply, State} response or the caller will block.
