### PR TITLE
Ignore everything after ; in a content types

### DIFF
--- a/src/mod_restful.erl
+++ b/src/mod_restful.erl
@@ -320,7 +320,7 @@ parse_http_request(#request{method = 'POST'} = Request) ->
 get_content_type(#request{headers = Headers}) ->
     case lists:keysearch('Content-Type', 1, Headers) of
         {value, {_, ContentType}} ->
-            ContentType;
+            hd(string:tokens(ContentType, ";"));
         _ ->
             undefined
     end.


### PR DESCRIPTION
Accept

```
Content-Type: application/json; charset=UTF-8
```

style headers.
