### PR TITLE
Change policy from Deny to Allow if AllowedCommands option is not defined.

### DIFF
--- a/src/mod_restful_admin.erl
+++ b/src/mod_restful_admin.erl
@@ -127,7 +127,7 @@ parse_json({struct, Struct}) ->
 command_allowed(Command, #rest_req{options = Options}) ->
     case gen_restful_api:opts(allowed_commands, Options) of
         undefined ->
-            deny;
+            allow;
         AllowedCommands ->
             case lists:member(Command, AllowedCommands) of
                 true -> allow;


### PR DESCRIPTION
The default behavior was to deny all commands if AllowedCommands option wasn't defined. Now if it so, it accepts all and deny only if the option is defined and the command isn't in the list.