### PR TITLE
Fix import paths ; format empty list to JSON.

### DIFF
--- a/include/mod_restful.hrl
+++ b/include/mod_restful.hrl
@@ -27,7 +27,7 @@
 -ifndef(mod_restful_hrl).
 -define(mod_restful_hrl, true).
 
--include_lib("ejabberd/include/ejabberd_http.hrl").
+-include_lib("ejabberd_http.hrl").
 
 -record(rest_req, {
         http_request :: #request{},

--- a/src/mod_restful.erl
+++ b/src/mod_restful.erl
@@ -54,7 +54,7 @@
     ]).
 -endif.
 
--include_lib("ejabberd/include/ejabberd.hrl").
+-include_lib("ejabberd.hrl").
 
 -include("mod_restful.hrl").
 

--- a/src/mod_restful_admin.erl
+++ b/src/mod_restful_admin.erl
@@ -62,9 +62,9 @@
 
 -behaviour(gen_restful_api).
 
--include_lib("ejabberd/include/ejabberd.hrl").
+-include_lib("ejabberd.hrl").
 
--include("include/mod_restful.hrl").
+-include("mod_restful.hrl").
 
 process_rest(#rest_req{http_request = #request{method = 'POST'}, path = Path} = Req) ->
     case tl(Path) of
@@ -185,11 +185,13 @@ format_result_json(Atom, {_, atom}) ->
 format_result_json(Int, {_, integer}) ->
     integer_to_list(Int);
 format_result_json(String, {_, string}) ->
-    list_to_binary(String);
+    String;
 format_result_json(Code, {_, rescode}) ->
     Code;
 format_result_json({Code, Text}, {_, restuple}) ->
     [{Code, list_to_binary(Text)}];
+format_result_json([], {_, {list, ElementsF}}) ->
+   [];
 format_result_json([E], {_, {list, ElementsF}}) ->
     [format_result_json(E, ElementsF)];
 format_result_json([E|T], {X, {list, ElementsF}}) ->
@@ -198,4 +200,3 @@ format_result_json(Tuple, {_, {tuple, ElementsF}}) ->
     TupleL = tuple_to_list(Tuple),
     % format a tuple as a list
     [format_result_json(E, F) || {E, F} <- lists:zip(TupleL, ElementsF)].
-


### PR DESCRIPTION
format_result_json for an empty list no longer yields a 400 bad request, but returns an empty Array, for instance for a get_roster call for a user that has an empty roster.

This includes the changes from jadahl/mod_restful#18 by @guitcastro

Please be gentle, erlang is not my forte.
